### PR TITLE
Fixing error/typo in install instructions (missing h)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The latest development version can be installed manually with these commands:
 
 ```sh
 git clone https://github.com/OttoAllmendinger/gnome-shell-screenshot.git
-cd gnome-shell-screensot
+cd gnome-shell-screenshot
 make install
 ```
 


### PR DESCRIPTION
The install instructions via github contained an error:
> cd gnome-shell-screensot
while it should be
> cd gnome-shell-screenshot