### PR TITLE
Re-adding 3.18 - needed at least on Ubuntu 16.04

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.20", "3.22"],
+    "shell-version": ["3.18", "3.20", "3.22"],
     "uuid": "gnome-shell-screenshot@ttll.de",
     "name": "Screenshot Tool",
     "url": "https://github.com/OttoAllmendinger/gnome-shell-screenshot/",


### PR DESCRIPTION
I was unable to enable the extension as my Ubuntu 16.04 (current / latest LTS)  is still running Gnome Shell 3.18. Therefor i would recommend re-adding 3.18