### PR TITLE
Fix typo in italian translation

### DIFF
--- a/src/locale/it/it.po
+++ b/src/locale/it/it.po
@@ -192,7 +192,7 @@ msgstr "Mostra il menu"
 
 #: src/prefs.js:169
 msgid "Auto-Copy to Clipboard"
-msgstr "Compia automaticamente negli appunti"
+msgstr "Copia automaticamente negli appunti"
 
 #: src/prefs.js:175
 msgid "Nothing"


### PR DESCRIPTION
It's "Copia", not "Compia" :)