### PR TITLE
Include 3.38 to Gnome Shell support list

### DIFF
--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.32", "3.34", "3.36"],
+    "shell-version": ["3.32", "3.34", "3.36", "3.38"],
     "uuid": "gnome-shell-screenshot@ttll.de",
     "name": "Screenshot Tool",
     "url": "https://github.com/OttoAllmendinger/gnome-shell-screenshot/",


### PR DESCRIPTION
The extension seems to be functional with Gnome Shell 3.38, let's add 3.38 to the support whitelist