### PR TITLE
Add support for GNOME 41

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.36", "3.38", "40"],
+    "shell-version": ["3.36", "3.38", "40", "41"],
     "uuid": "gnome-shell-screenshot@ttll.de",
     "name": "Screenshot Tool",
     "url": "https://github.com/OttoAllmendinger/gnome-shell-screenshot/",


### PR DESCRIPTION
openSUSE Tumbleweed and other distros have been shipping GNOME 41 for a bit;
luckily simply adding that version to the list of supported versions appears sufficient.