### PR TITLE
Enabled support for Gnome 42.

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["40","41"],
+    "shell-version": ["40","41","42"],
     "uuid": "gnome-shell-screenshot@ttll.de",
     "name": "Screenshot Tool",
     "url": "https://github.com/OttoAllmendinger/gnome-shell-screenshot/",


### PR DESCRIPTION
Hello Otto,

Really enjoying your Screenshot Tool extension!

After upgrading to Gnome 42 recently, I manually changed _metadata.json_ to enabled support for Gnome 42. Your extension seems to work fine on it. I've been using it for over a week now. I figured I might as well create a pull request for this minor little change. Hopefully this will result in a new release of this extension on the Gnome Extensions website in the near future.

Take care,

Frank